### PR TITLE
Fix: fix build error on Linux

### DIFF
--- a/scripts/build_helper.rs
+++ b/scripts/build_helper.rs
@@ -29,7 +29,7 @@ impl OS {
 
     pub fn platform_name(&self) -> &'static str {
         match self {
-            OS::Linux => "linux",
+            OS::Linux => "linux-gnu",
             OS::MacOS => "darwin",
             OS::Windows => "windows",
         }


### PR DESCRIPTION
it seems like the `Release` section expect `linux-gnu` as a platform name 
and cause the `tar -xzf` trying to extract the file that does not exist which was causing the issue on Linux enviroment
```
--- stderr

  gzip: stdin: not in gzip format
  tar: Child returned status 1
  tar: Error is not recoverable: exiting now

  thread 'main' panicked at build.rs:68:45:
  Failed to install XLA extension: "Tar extraction failed"
 ```